### PR TITLE
Fix race condition in loading fact data

### DIFF
--- a/stores/MathFactsStore.js
+++ b/stores/MathFactsStore.js
@@ -173,7 +173,7 @@ var fetchFactData = function() {
       newFactData[operation] = (data == null) ? [] : data;
     });
     _factData = newFactData;
-  }).done();
+  });
 };
 
 var updateStoredFactData = function() {


### PR DESCRIPTION
Calling `.done()` on a Promise to terminate a chain is good practice in order to throw an error for uncaught rejections, but it turns out `.done()` doesn't actually return a promise itself, so `fetchFactData()` always returned `undefined` and so `fetchStoredData()` wouldn't wait for it to finish before emitting the change event. (Using a non-Promise value with Promise.all is equivalent to passing an already-resolved Promise with that value, so Promise.all only waited for `fetchPoints()` in this case.)

Test Plan: Applied

``` diff
diff --git a/stores/MathFactsStore.js b/stores/MathFactsStore.js
index 6a8d578..e7fae87 100644
--- a/stores/MathFactsStore.js
+++ b/stores/MathFactsStore.js
@@ -163,6 +163,12 @@ var addAttempts = function(operation, data) {

 var fetchFactData = function() {
   return AsyncStorage.getItem(createKey('factData')).then((factData) => {
+    return new Promise(function(res, rej) {
+      setTimeout(function() {
+        res(factData);
+      }, 3000);
+    });
+  }).then((factData) => {
     var newFactData = {};
     var factData = JSON.parse(factData);
     if (factData == null) {
```

to simulate slow fetching of fact data, verified that the stats page loads after a few seconds (whereas it consistently didn't before this fix).
